### PR TITLE
fix: add missing right parenthesis for Q4 line 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Further reading:
 ```js
 setTimeout(() => console.log(1));
 Promise.resolve().then(() => console.log(2));
-Promise.resolve().then(() => setTimeout(() => console.log(3));
+Promise.resolve().then(() => setTimeout(() => console.log(3)));
 new Promise(() => console.log(4));
 setTimeout(() => console.log(5));
 ```


### PR DESCRIPTION
The missing parenthesis causes a `SyntaxError` when the code is executed.